### PR TITLE
added #includes for compilation on g++ 4.4.3

### DIFF
--- a/src/shuffle/shuffle.cpp
+++ b/src/shuffle/shuffle.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <vector>

--- a/src/stats/stats.cpp
+++ b/src/stats/stats.cpp
@@ -1,3 +1,5 @@
+#include <climits>
+#include <cstring>
 #include <iostream>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
I had trouble compiling filo in Ubuntu 10.04, which has gcc/g++ version 4.4.3 in the repos.  Upon compiling, I got errors like

```
shuffle.cpp:32: error: ‘strlen’ was not declared in this scope
```

So I made minor tweaks to stats.cpp and shuffle.cpp as described in http://gcc.gnu.org/gcc-4.3/porting_to.html and now it works like a charm.  Hopefully these #includes are backwards-compatible?

-ryan
