### PR TITLE
omit trailing comma with collapse operation

### DIFF
--- a/src/groupBy/groupBy.cpp
+++ b/src/groupBy/groupBy.cpp
@@ -426,12 +426,15 @@ void ReportSummary(const vector<string> &group, const vector<vector<string> > &d
         }
         else if (op == "collapse") {
             string collapse;
-            for( size_t j = 0; j < data[i].size(); j++ ) {//Ugly, but cannot use back_inserter
-                if (j>0)
+            size_t data_size = data[i].size();
+            if (data_size > 0) {
+                for( size_t j = 0; j < data_size - 1; j++ ) {
+                    collapse.append(data[i][j]);
                     collapse.append(",");
-                collapse.append(data[i][j]);
+                }
+                collapse.append(data[i][data_size - 1]);
+                result.push_back(collapse);
             }
-            result.push_back(collapse);
         }
         else if (op == "distinct") {
             string distinct;


### PR DESCRIPTION
Before

```
$ groupBy -i ex1.out -g 1,2,3,4 -c 8,9 -o collapse,mean
chr1 10  20  A   B.1,B.2,    5500
```

After

```
$ groupBy -i ex1.out -g 1,2,3,4 -c 8,9 -o collapse,mean
chr1 10  20  A   B.1,B.2    5500
```
