### PR TITLE
Fix sefault when given no data

### DIFF
--- a/src/stats/stats.cpp
+++ b/src/stats/stats.cpp
@@ -205,6 +205,9 @@ int main(int argc, char* argv[]) {
     cout << "Total lines:\t\t"  << setprecision (15) << totalLines << endl;
     cout << "Sum of lines:\t\t" << setprecision (15) << sumOfLines << endl;
 
+    if (totalLines < 1) {
+        return 0;
+    }
     if (doMean || doAll) {
         // compute the mean
         mean = sumOfLines / totalLines;


### PR DESCRIPTION
Hi Aaron,

[Project Mayhem](http://forallsecure.com/mayhem.html), and effort to fuzz-test all Debian packages, found [an issue](https://bugs.debian.org/716357) with the stats command which causes a segfault when given no data. I have patched the filo package with the attached patch, and confirmed that it fixes the bug.

In short, during calculation of the mid-point for the median, and index of -1 is generated and used when no data is present (`totalLines == 0`). This patch skips all further operations when there are no lines to process.
